### PR TITLE
Implement various features for `estate show/list`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ source "https://rubygems.org"
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
 gem 'activemodel', require: 'active_model'
-gem 'activesupport', require: 'active_support/core_ext'
+gem 'activesupport', ">= 5.2.4.3", require: 'active_support/core_ext'
 gem 'figaro'
 gem 'flight_facade', '>= 0.1.5', require: 'flight_facade/included'
 gem 'hashie'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (5.2.4.1)
-      activesupport (= 5.2.4.1)
-    activesupport (5.2.4.1)
+    activemodel (5.2.4.4)
+      activesupport (= 5.2.4.4)
+    activesupport (5.2.4.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -12,7 +12,7 @@ GEM
     byebug (11.0.1)
     climate_control (0.2.0)
     coderay (1.1.2)
-    concurrent-ruby (1.1.6)
+    concurrent-ruby (1.1.7)
     diff-lcs (1.3)
     figaro (1.1.1)
       thor (~> 0.14)
@@ -22,14 +22,14 @@ GEM
       hashie
       jsonapi-serializers (~> 1.0)
     hashie (4.1.0)
-    i18n (1.8.2)
+    i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     json (2.3.0)
     jsonapi-serializers (1.0.1)
       activesupport
     jwt (2.2.1)
     method_source (0.9.2)
-    minitest (5.14.0)
+    minitest (5.14.2)
     multi_json (1.14.1)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
@@ -86,7 +86,7 @@ GEM
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    tzinfo (1.2.6)
+    tzinfo (1.2.7)
       thread_safe (~> 0.1)
 
 PLATFORMS
@@ -94,7 +94,7 @@ PLATFORMS
 
 DEPENDENCIES
   activemodel
-  activesupport
+  activesupport (>= 5.2.4.3)
   climate_control
   figaro
   flight_facade (>= 0.1.5)

--- a/app.rb
+++ b/app.rb
@@ -172,7 +172,10 @@ class App < Sinatra::Base
     show
 
     create do |attributes|
-      ticket = Ticket.new(arguments: attributes[:arguments])
+      attrs = [:arguments, :request_uid, :request_username].map do |key|
+        [key, attributes[key]]
+      end.to_h
+      ticket = Ticket.new(**attrs)
       next [ticket.id, ticket]
     end
 

--- a/app/models.rb
+++ b/app/models.rb
@@ -97,8 +97,12 @@ class Job < BaseHashieDashModel
       node.params.stringify_keys.dup.tap { |e| e['name'] = node.name }
     else
       {}
-    end.tap { |e| e['SCRIPT_ROOT'] = Figaro.env.command_directory_path }
-       .tap { |e| e['command'] = ticket.command.name }
+    end.tap do |env|
+      env['SCRIPT_ROOT']      = Figaro.env.command_directory_path
+      env['command']          = ticket.command.name
+      env['request_username'] = ticket.request_username.to_s
+      env['request_uid']      = ticket.request_uid.to_s
+    end
   end
 
   def completed?

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -74,6 +74,10 @@ class Ticket
   attribute :arguments, default: []
   attribute :jobs, default: ->() { Array.new } # Ensure a new array is created each time
 
+  # NOTE: For backwards compatibility purposes, these are not required
+  attribute :request_username,  default: ''
+  attribute :request_uid,       default: ''
+
   validates :context,  presence: true, if: :command_has_context?
   validates :context,  absence: true, unless: :command_has_context?
   validates :command,  presence: true

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -74,13 +74,18 @@ class Ticket
   attribute :arguments, default: []
   attribute :jobs, default: ->() { Array.new } # Ensure a new array is created each time
 
-  # NOTE: For backwards compatibility purposes, these are not required
   attribute :request_username,  default: ''
-  attribute :request_uid,       default: ''
+  attribute :request_uid
 
   validates :context,  presence: true, if: :command_has_context?
   validates :context,  absence: true, unless: :command_has_context?
   validates :command,  presence: true
+
+  # NOTE: For backwards compatibility purposes, the request_username/uid maybe empty
+  validates :request_username, format: {
+    with: /[\w.-]*/, message: 'is not a valid username'
+  }
+  validates :request_uid, numericality: { only_integer: true, allow_nil: true }
 
   def nodes
     if context.is_a?(Node)

--- a/docs/routes.md
+++ b/docs/routes.md
@@ -248,7 +248,9 @@ Authorization: Bearer <jwt>
   "data": {
     "type": "tickets",
     "attributes": {
-      ["arguments: ARRAY<STRING>]
+      ["arguments: ARRAY<STRING>],
+      ["request_username": STRING],
+      ["request_UID": INTEGER|STRING]
     "relationships": {
       "command": COMMAND_RESOURCE_IDENTIFIER_OBJECT,
       ["context": GROUP_OR_NODE_RESOURCE_IDENTIFIER_OBJECT]

--- a/libexec/estate-grow/default.sh
+++ b/libexec/estate-grow/default.sh
@@ -103,7 +103,7 @@ for channel in "${channels[@]}"; do
   "text": "Received a \`flight-estate\` modification request!",
   "attachments": [
     {
-      "text": "*Cluster*: $flight_ESTATE_cluster\n*Action*: $__flight_ESTATE_action\n*Machine Type*: $machine_type\n*Number*: $number"
+      "text": "*Unauthenticated User:* $request_username($request_uid)\n*Cluster*: $flight_ESTATE_cluster\n*Action*: $__flight_ESTATE_action\n*Machine Type*: $machine_type\n*Number*: $number"
     }
   ]
 }

--- a/libexec/estate-grow/default.sh
+++ b/libexec/estate-grow/default.sh
@@ -103,7 +103,7 @@ for channel in "${channels[@]}"; do
   "text": "Received a \`flight-estate\` modification request!",
   "attachments": [
     {
-      "text": "*Unauthenticated User:* $request_username($request_uid)\n*Cluster*: $flight_ESTATE_cluster\n*Action*: $__flight_ESTATE_action\n*Machine Type*: $machine_type\n*Number*: $number"
+      "text": "*Unauthenticated User:* $request_username ($request_uid)\n*Cluster*: $flight_ESTATE_cluster\n*Action*: $__flight_ESTATE_action\n*Machine Type*: $machine_type\n*Number*: $number"
     }
   ]
 }

--- a/libexec/estate-grow/default.sh
+++ b/libexec/estate-grow/default.sh
@@ -103,7 +103,7 @@ for channel in "${channels[@]}"; do
   "text": "Received a \`flight-estate\` modification request!",
   "attachments": [
     {
-      "text": "*Unauthenticated User:* $request_username ($request_uid)\n*Cluster*: $flight_ESTATE_cluster\n*Action*: $__flight_ESTATE_action\n*Machine Type*: $machine_type\n*Number*: $number"
+      "text": "*User (Unauthenticated):* $request_username ($request_uid)\n*Cluster*: $flight_ESTATE_cluster\n*Action*: $__flight_ESTATE_action\n*Machine Type*: $machine_type\n*Number*: $number"
     }
   ]
 }

--- a/libexec/estate-show/aws.sh
+++ b/libexec/estate-show/aws.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+if [[ -z "${ec2_id}" ]]; then
+    echo "The ec2_id for node '$name' has not been set!" >&2
+    exit 1
+fi
+if [[ -z "${aws_region}" ]]; then
+    echo "The aws_region for node '$name' has not been set!" >&2
+    exit 1
+fi
+
+aws_instance_type=$(
+aws ec2 describe-instance-attribute \
+  --attribute instanceType \
+  --query InstanceType.Value \
+  --instance-id "$ec2_id" \
+  --region "$aws_region"
+)
+
+exit_code=$?
+
+if [ ${exit_code} -eq 0 ] ; then
+  machine_type=$(case "$aws_instance_type" in
+  ('"t2.small"') "general-small" ;;
+  ('"t2.large"') "general-large" ;;
+  ('"c4.large"') "compute-2C-3.75GB" ;;
+  ('"c4.2xlarge"') "compute-8C-15GB" ;;
+  ('"p3.2xlarge"') "gpu-1GPU-8C-61GB" ;;
+  ('"p3.8xlarge"') "gpu-4GPU-32C-244GB" ;;
+  (*) 'unknown' ;;
+  esac)
+
+  echo "$name": "$machine_type"
+else
+    # Standard error from the `aws` call should be enough to debug this.
+    :
+fi
+
+exit ${exit_code}
+

--- a/libexec/estate-show/aws.sh
+++ b/libexec/estate-show/aws.sh
@@ -56,7 +56,7 @@ if [ ${exit_code} -eq 0 ] ; then
   (*) 'unknown' ;;
   esac)
 
-  echo "$name": "$machine_type"
+  echo "$machine_type"
 else
     # Standard error from the `aws` call should be enough to debug this.
     :

--- a/libexec/estate-show/aws.sh
+++ b/libexec/estate-show/aws.sh
@@ -1,4 +1,30 @@
 #!/bin/bash
+#==============================================================================
+# Copyright (C) 2020-present Alces Flight Ltd.
+#
+# This file is part of Flight Action API.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# Flight Action API is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Action API. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Action API, please visit:
+# https://github.com/openflighthpc/flight-action-api
+#===============================================================================
 
 if [[ -z "${ec2_id}" ]]; then
     echo "The ec2_id for node '$name' has not been set!" >&2
@@ -21,12 +47,12 @@ exit_code=$?
 
 if [ ${exit_code} -eq 0 ] ; then
   machine_type=$(case "$aws_instance_type" in
-  ('"t2.small"') "general-small" ;;
-  ('"t2.large"') "general-large" ;;
-  ('"c4.large"') "compute-2C-3.75GB" ;;
-  ('"c4.2xlarge"') "compute-8C-15GB" ;;
-  ('"p3.2xlarge"') "gpu-1GPU-8C-61GB" ;;
-  ('"p3.8xlarge"') "gpu-4GPU-32C-244GB" ;;
+  ('"t2.small"')    echo "general-small" ;;
+  ('"t2.large"')    echo "general-large" ;;
+  ('"c4.large"')    echo "compute-2C-3.75GB" ;;
+  ('"c4.2xlarge"')  echo "compute-8C-15GB" ;;
+  ('"p3.2xlarge"')  echo "gpu-1GPU-8C-61GB" ;;
+  ('"p3.8xlarge"')  echo "gpu-4GPU-32C-244GB" ;;
   (*) 'unknown' ;;
   esac)
 

--- a/libexec/estate-show/aws.sh
+++ b/libexec/estate-show/aws.sh
@@ -53,7 +53,7 @@ if [ ${exit_code} -eq 0 ] ; then
   ('"c4.2xlarge"')  echo "compute-8C-15GB" ;;
   ('"p3.2xlarge"')  echo "gpu-1GPU-8C-61GB" ;;
   ('"p3.8xlarge"')  echo "gpu-4GPU-32C-244GB" ;;
-  (*) 'unknown' ;;
+  (*)               echo "unknown" ;;
   esac)
 
   echo "$machine_type"

--- a/libexec/estate-show/default.sh
+++ b/libexec/estate-show/default.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "$name: unknown"

--- a/libexec/estate-show/metadata.yaml
+++ b/libexec/estate-show/metadata.yaml
@@ -1,0 +1,3 @@
+help:
+  summary: 'Display details about a node'
+


### PR DESCRIPTION
This implements the following features:

* Receives the `request_username` and `request_uid` from the client and passes it through to the scripts,
* Allows command outputs to be `sequential`, this disables the interlacing of outputs between nodes. The underlining commands are still ran concurrently and buffered
* Allows a command to be ran against every node in the cluster with `has_context: all_nodes`

The `has_context: all_nodes` is the biggest change in this PR. It required making a distinction between explicit context and implicit context. The commands still have a "pseudo context" when ran against every node, but this is hidden from the client. This means `has_context` is now a bit of a misnomer with the possible meanings:

* Has an explicit context, either a `node` or `group` from the CLI,
* Has no context and runs the default script instead, and
* Somewhere in between. No context was specified on the CLI but the command is still ran against each node with rank lookup.

The following changes have been made to the estate commands:

* The `e'grow` and `e'shrink` commands now display the username and uid in the slack message
* The `e'show` has been implemented as request with a `aws` and `default` script
* The `e'list` uses the new `has_context: all_nodes` mechanism to wrap `e'show`. This allows each node to run a script with a different rank