### PR TITLE
Update machine type definitions

### DIFF
--- a/libexec/estate-change/machine-type-definitions.sh
+++ b/libexec/estate-change/machine-type-definitions.sh
@@ -32,12 +32,21 @@
 # metadata files.
 declare -A MACHINE_TYPE_MAP
 MACHINE_TYPE_MAP=(
-  [general-small]=t2.small
-  [general-large]=t2.large
-  [compute-2C-3.75GB]=c4.large
-  [compute-8C-15GB]=c4.2xlarge
-  [gpu-1GPU-8C-61GB]=p3.2xlarge
-  [gpu-4GPU-32C-244GB]=p3.8xlarge
+  [general-small]=t3.medium
+  [general-medium]=t3.xlarge
+  [general-large]=t3.2xlarge
+
+  [compute-small]=c5.large
+  [compute-medium]=c5.xlarge
+  [compute-large]=c5.2xlarge
+
+  [gpu-small]=p3.2xlarge
+  [gpu-medium]=p3.8xlarge
+  [gpu-large]=p3.16xlarge
+
+  [mem-small]=r5.large
+  [mem-medium]=r5.xlarge
+  [mem-large]=r5.2xlarge
 )
 
 # An array of machine types.

--- a/libexec/estate-change/machine-type-definitions.sh
+++ b/libexec/estate-change/machine-type-definitions.sh
@@ -75,7 +75,8 @@ validate_machine_type() {
     if [ "${MACHINE_TYPE_MAP[${1}]}" == "" ]; then
         cat 1>&2 <<ERROR
 Unknown machine type ${1}.  Available machine types:
-$( printf '%s\n' "${MACHINE_TYPE_NAMES[@]}" )
+
+$( printf '  %s\n' "${MACHINE_TYPE_NAMES[@]}" )
 ERROR
         exit 1
     fi

--- a/libexec/estate-change/metadata.yaml
+++ b/libexec/estate-change/metadata.yaml
@@ -33,12 +33,18 @@ help:
   description: |
     Change the machine type for a node or all nodes in the specified group to TYPE.  The available types are:
 
-    compute-2C-3.75GB
-    compute-8C-15GB
-    general-large
-    general-small
-    gpu-1GPU-8C-61GB
-    gpu-4GPU-32C-244GB
+      compute-large
+      compute-medium
+      compute-small
+      general-large
+      general-medium
+      general-small
+      gpu-large
+      gpu-medium
+      gpu-small
+      mem-large
+      mem-medium
+      mem-small
 
     WARNING: If the node is currently powered on, it will be powered off and then powered back on.
 

--- a/libexec/estate-grow/metadata.yaml
+++ b/libexec/estate-grow/metadata.yaml
@@ -37,9 +37,15 @@ help:
 
     The available types are:
 
-      compute-2C-3.75GB
-      compute-8C-15GB
+      compute-large
+      compute-medium
+      compute-small
       general-large
+      general-medium
       general-small
-      gpu-1GPU-8C-61GB
-      gpu-4GPU-32C-244GB
+      gpu-large
+      gpu-medium
+      gpu-small
+      mem-large
+      mem-medium
+      mem-small

--- a/libexec/estate-show/aws.sh
+++ b/libexec/estate-show/aws.sh
@@ -54,7 +54,7 @@ if [ ${exit_code} -eq 0 ] ; then
 
     machine_type="${REVERSE_MACHINE_TYPE_MAP[$aws_instance_type]}"
     if [ "${machine_type}" == "" ]; then
-        echo "unknown"
+        echo "unknown (${aws_instance_type})"
     else
         echo "${machine_type}"
     fi

--- a/libexec/estate-show/default.sh
+++ b/libexec/estate-show/default.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-echo "$name: unknown"
+echo "unknown"

--- a/libexec/estate-shrink/metadata.yaml
+++ b/libexec/estate-shrink/metadata.yaml
@@ -37,9 +37,15 @@ help:
 
     The available types are:
 
-      compute-2C-3.75GB
-      compute-8C-15GB
+      compute-large
+      compute-medium
+      compute-small
       general-large
+      general-medium
       general-small
-      gpu-1GPU-8C-61GB
-      gpu-4GPU-32C-244GB
+      gpu-large
+      gpu-medium
+      gpu-small
+      mem-large
+      mem-medium
+      mem-small


### PR DESCRIPTION
This PR updates the machine type definitions in line with the definitions in the latest "Upfront Cloud Cost Calcs" spreadsheet.  A example interaction now looks like this:

```
[flight@gateway1 (ben1) ~]$ flight estate show node02
unknown                                            
[flight@gateway1 (ben1) ~]$ flight estate change node02 general-xsuperlargexxx
Change machine type for node02. If powered on it will be rebooted. Confirm to proceed [y/n]?
y
Unknown machine type general-xsuperlargexxx.  Available machine types:

  compute-large
  compute-medium
  compute-small
  general-large
  general-medium
  general-small
  gpu-large
  gpu-medium
  gpu-small
  mem-large
  mem-medium
  mem-small
[flight@gateway1 (ben1) ~]$ flight estate change node02 general-large --confirm
Changing machine type...                            
OK
[flight@gateway1 (ben1) ~]$ flight estate show node02
general-large                                       
[flight@gateway1 (ben1) ~]$ flight estate change node02 general-small --confirm
Changing machine type...                             
OK
[flight@gateway1 (ben1) ~]$ flight estate show node02
general-small  
```

---

No support has been added for dealing with "old machine types".  Whlist, the `estate show NODE` command has not yet been released, we could still end up with the following situation.


* On the current release of `flight-action-api-estate` set `node01` to `general-small` (aka `t2.small`).
   ```
   $ flight estate change node01 general-small
   ```

* Update `flight-action-api-estate`, which updates the definition of `general-small` to `t3.small`.
   ```
   $ flight estate show node01
   unknown
   ```

I'm not sure what the desired behaviour here is.  We could:

1. Maintain a "deprecated machine type mapping", so that `flight estate show node01` would output `general-small (old definition)` or something similar.

2. Automatically upgrade the machine types.  Probably a bad idea.

3. Include a postinst script which informs the admin that the definitions have changed and suggests that they change the machine types.

4. Some combination of the above.